### PR TITLE
Add the ability to specify resetValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 coverage/
 .rpt2_cache/
+yarn-error.log

--- a/src/createFilter.ts
+++ b/src/createFilter.ts
@@ -10,17 +10,23 @@ export default function createFilter<T>(paramName: string, config?: FilterConfig
   );
 
   const defaultConfig = {
-    parse(input: string | undefined): any { return input; }, 
+    parse(input: string | undefined): any { return input; },
     format(value: T): string { return String(value); },
     validate(): boolean { return true; },
     defaultValue: undefined,
+    resetValue: undefined,
     [FILTER_OBJECT_MARKER]: true,
     [FILTER_HAS_OVEWRITES]: !config,
   };
+
+  // by default, resetValue is the same as defaultValue
+  if (config && !config.hasOwnProperty("resetValue")) {
+    config.resetValue = config.defaultValue;
+  }
 
   return {
     ...defaultConfig,
     ...config,
     paramName,
   };
-}; 
+};

--- a/src/useReset.ts
+++ b/src/useReset.ts
@@ -22,29 +22,29 @@ export default function useReset(filter?: FilterDefinition): FilterResetter {
   if (filter) {
     invariant(
       (isFilterComposition(filter) || isFilterObject(filter)),
-      `refilterable: you called useReset() and passed an invalid filter object. 
-      Instead of constructing the configuration object on your own, 
+      `refilterable: you called useReset() and passed an invalid filter object.
+      Instead of constructing the configuration object on your own,
       use createFilter() or composeFilters().`
     );
 
     filtersToReset = isFilterComposition(filter) ? filter.filters : [filter];
   }
-  
+
   // @ts-ignore because this is checked by invariant
   const { locationObserver, history, filterRegistry } = context;
 
   const reset = useCallback((options: SetFilterOptions = defaultSetFilterOptions): string => {
     const params = locationObserver.getCurrentParams();
-    
+
     (filtersToReset || filterRegistry.getAllFilters())
-      .forEach(({ paramName, defaultValue }: FilterObject<any>) => {
-        if (typeof defaultValue === "undefined") {
+      .forEach(({ paramName, resetValue }: FilterObject<any>) => {
+        if (typeof resetValue === "undefined") {
           params.delete(paramName);
         } else {
-          params.set(paramName, defaultValue);
+          params.set(paramName, resetValue);
         }
       });
-      
+
     return applyHistoryAction(history, params, options);
   }, [history]);
 

--- a/src/useReset.ts
+++ b/src/useReset.ts
@@ -37,11 +37,11 @@ export default function useReset(filter?: FilterDefinition): FilterResetter {
     const params = locationObserver.getCurrentParams();
 
     (filtersToReset || filterRegistry.getAllFilters())
-      .forEach(({ paramName, resetValue }: FilterObject<any>) => {
+      .forEach(({ paramName, format, resetValue }: FilterObject<any>) => {
         if (typeof resetValue === "undefined") {
           params.delete(paramName);
         } else {
-          params.set(paramName, resetValue);
+          params.set(paramName, format(resetValue));
         }
       });
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,19 +4,21 @@ import { FILTER_OBJECT_MARKER, FILTER_COMPOSITION_MARKER } from './constants';
 
 export type ParseFunction<T> = (input: string) => T | undefined;
 
-export interface FilterConfig<T = string> {
-	parse?: ParseFunction<T>;
-  format?(value: T): string; 
-  validate?(input: string, parse: ParseFunction<T>): boolean;
-  defaultValue?: string | undefined;
-}
-
 export interface FilterObject<T = undefined> {
   paramName: string;
-	parse: ParseFunction<T>;
-  format(value: T): string; 
+  parse: ParseFunction<T>;
+  format(value: T): string;
   validate(input: string, parse: ParseFunction<T>): boolean;
   defaultValue?: string | undefined;
+  resetValue?: string | undefined;
+}
+
+export interface FilterConfig<T = string> {
+  parse?: ParseFunction<T>;
+  format?(value: T): string;
+  validate?(input: string, parse: ParseFunction<T>): boolean;
+  defaultValue?: string | undefined;
+  resetValue?: string | undefined;
 }
 
 export interface FilterComposition {
@@ -28,8 +30,8 @@ export type FilterDefinition<T = any> = FilterObject<T> | FilterComposition;
 
 /**
  * User defined type guard to check if the passed object is a valid instance of FiterObject
- * 
- * @param filter 
+ *
+ * @param filter
  */
 export function isFilterObject<T = any>(filter: FilterDefinition<T>): filter is FilterObject<T> {
   return Boolean(filter[FILTER_OBJECT_MARKER]);
@@ -37,8 +39,8 @@ export function isFilterObject<T = any>(filter: FilterDefinition<T>): filter is 
 
 /**
  * User defined type guard to check if the passed object is a valid instance of FiterObject
- * 
- * @param filter 
+ *
+ * @param filter
  */
 export function isFilterComposition<T = undefined>(filter: FilterDefinition<T>): filter is FilterComposition {
   return Boolean(filter[FILTER_COMPOSITION_MARKER]);

--- a/tests/__snapshots__/useReset.test.tsx.snap
+++ b/tests/__snapshots__/useReset.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`useReset should throw an error if the value provided is not a filter 1`] = `
-"refilterable: you called useReset() and passed an invalid filter object. 
-      Instead of constructing the configuration object on your own, 
+"refilterable: you called useReset() and passed an invalid filter object.
+      Instead of constructing the configuration object on your own,
       use createFilter() or composeFilters()."
 `;
 

--- a/tests/createFilter.test.ts
+++ b/tests/createFilter.test.ts
@@ -27,6 +27,13 @@ describe('createFilter', () => {
     expect(filter.validate('foo', filter.parse)).toBe(true);
   });
 
+  test('resetValue should fall back to defaultValue', () => {
+    const filter = createFilter('foo', { defaultValue: "bar" });
+
+    expect(filter.resetValue).toBe(filter.defaultValue);
+    expect(filter.resetValue).toBe("bar");
+  });
+
   it('should allow the user to override parse, format, and validate methods', () => {
     const parse = jest.fn();
     const format = jest.fn();

--- a/tests/useReset.test.tsx
+++ b/tests/useReset.test.tsx
@@ -177,4 +177,28 @@ describe('useReset', () => {
     expect(foo).toBe("bar");
   });
 
+  it('should call the formatter before resetting filters', () => {
+    const filter = createFilter("foo", {
+      format: jest.fn().mockReturnValue("bar"),
+      resetValue: "bar",
+    });
+
+    const { result: hooks } = renderHook(() => [
+      useFilter(filter),
+      useReset(),
+    ], { wrapper });
+
+    act(() => {
+      const reset = hooks.current[1];
+      // @ts-ignore
+      reset();
+    });
+
+    // @ts-ignore
+    const [foo] = hooks.current[0];
+
+    expect(foo).toBe("bar");
+    expect(filter.format).toHaveBeenCalledWith("bar");
+  });
+
 });

--- a/tests/useReset.test.tsx
+++ b/tests/useReset.test.tsx
@@ -9,9 +9,9 @@ describe('useReset', () => {
 
   beforeEach(() => {
     history = createMemoryHistory();
-    
+
     wrapper = ({ children }) => (
-      <FiltersProvider 
+      <FiltersProvider
         history={history}
       >
         {children}
@@ -58,7 +58,7 @@ describe('useReset', () => {
       // @ts-ignore
       nextSearch = reset();
     });
-    
+
     const [fooHook, barHook] = hooks.current;
     expect(history.location.search).toBe('?bar=bar');
     expect(nextSearch).toBe('bar=bar');
@@ -135,7 +135,7 @@ describe('useReset', () => {
 
   it('should not change the URL if the "dry" option is set to true', () => {
     history.push({ search: 'foo=bar' });
-    
+
     const { result: hooks } = renderHook(() => [
       useFilter('foo'),
       useReset(),
@@ -156,5 +156,25 @@ describe('useReset', () => {
     expect(foo).toBe('bar');
     expect(nextSearch).toBe('');
   });
-  
+
+  it('should use resetValue instead of defaultValue if the former is specified', () => {
+    const filter = createFilter("foo", { defaultValue: "foo", resetValue: "bar" });
+
+    const { result: hooks } = renderHook(() => [
+      useFilter(filter),
+      useReset(),
+    ], { wrapper });
+
+    act(() => {
+      const reset = hooks.current[1];
+      // @ts-ignore
+      reset();
+    });
+
+    // @ts-ignore
+    const [foo] = hooks.current[0];
+
+    expect(foo).toBe("bar");
+  });
+
 });


### PR DESCRIPTION
This PR adds the ability to have distinction between `defaultValue` and `resetValue`. From now on, `defaultValue` is what you get when nothing is passed and `resetValue` is what's going to be used when you reset