### PR TITLE
Stop filters from being removed from registry if they're still being used

### DIFF
--- a/src/useFilter.ts
+++ b/src/useFilter.ts
@@ -74,7 +74,7 @@ export default function useFilter<T = undefined>(
         `refilterable: you attempted to register conflicting configurations for the "${filter.paramName}" filter`
       );
 
-      filterRegistry.addFilter(filter);
+      filterRegistry.addFilterUse(filter);
 
       // 2) subscribe to changes in location
       unsubscribers[filter.paramName] = locationObserver.watch(filter.paramName, () => (
@@ -86,7 +86,7 @@ export default function useFilter<T = undefined>(
       // unsusbscribe and remove filter from the registry
       filters.forEach((filter) => {
         unsubscribers[filter.paramName](filter.paramName)
-        filterRegistry.removeFilter(filter)
+        filterRegistry.deleteFilterUse(filter)
       });
     }
   }, paramNames);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -56,8 +56,8 @@ export interface LocationObserver {
 export interface FilterRegistry {
   getAllFilters(): FilterObject<any>[];
   isColliding(filter: FilterObject<any>): boolean;
-  addFilter(filter: FilterObject<any>): void;
-  removeFilter(filter: FilterObject<any>): void;
+  addFilterUse(filter: FilterObject<any>): void;
+  deleteFilterUse(filter: FilterObject<any>): void;
 }
 
 export type FiltersContextValue = {

--- a/tests/utils/createFilterRegistry.test.ts
+++ b/tests/utils/createFilterRegistry.test.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import { History } from 'history';
+import { render, act as reactTestingLibraryAct } from '@testing-library/react'
+import { renderHook, act } from 'react-hooks-testing-library'
+import { createMemoryHistory } from 'history';
+import { useFilter, FiltersProvider, createFilter, composeFilters } from '../../src';
+import createFilterRegistry from '../../src/utils/createFilterRegistry';
+import { FilterRegistry, FilterObject } from '../../src/utils/types';
+
+describe('utils/createFilterRegistry', () => {
+  let filter: FilterObject, registry: FilterRegistry;
+
+  beforeEach(() => {
+    filter = createFilter('foo');
+    registry = createFilterRegistry();
+  });
+
+  it('should allow you to add a filter uses', () => {
+    registry.addFilterUse(filter);
+    expect(registry.getAllFilters()).toContain(filter);
+  });
+
+  it('should delete filter if it is not used anymore', () => {
+    registry.addFilterUse(filter);
+    registry.deleteFilterUse(filter);
+    expect(registry.getAllFilters()).not.toContain(filter);
+  });
+
+  it('should not delete a filter if someone is still using it', () => {
+    registry.addFilterUse(filter);
+    registry.addFilterUse(filter);
+    registry.deleteFilterUse(filter);
+    expect(registry.getAllFilters()).toContain(filter);
+  });
+});


### PR DESCRIPTION
If two components that use the same filter are mounted and then one of them gets unmounted, it removes the filter from the registry of filters. This behavior is incorrect and is known to cause `useReset` not to reset impacted filters. This PR addresses the issue by counting references to the filter and removing it from the registry only when the last reference is lost.