### PR TITLE
Fire notify initially.

### DIFF
--- a/src/FiltersProvider.tsx
+++ b/src/FiltersProvider.tsx
@@ -27,6 +27,9 @@ const FiltersProvider: FunctionComponent<Props> = ({ history, children }: Props)
       locationObserver.current.notify(location.search);
     });
 
+    // fire once, to capture current location
+    locationObserver.current.notify(history.location.search);
+
     // unsubscribe when the component unmounts
     return unlisten;
   }, []);


### PR DESCRIPTION
Fire notify "notify" initially, in order to capture the state of location, when all child components of FiterProvider get loaded.