### PR TITLE
Fix unused/unresolved imports and FilterProvider's children prop type

### DIFF
--- a/src/FiltersProvider.tsx
+++ b/src/FiltersProvider.tsx
@@ -8,10 +8,9 @@ import createLocationObserver from './utils/createLocationObserver';
  
 type Props = {
   history: History;
-  children: JSX.Element[];
 }
 
-const FiltersProvider: FunctionComponent<Props> = ({ history, children }: Props) => {
+const FiltersProvider: FunctionComponent<Props> = ({ history, children }) => {
   invariant(
     history,
     `refilterable: FiltersProvider was not passed a history instance. 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,3 @@
-import { FilterComposition, FilterObject } from './types';
 import { History } from 'history';
 import { FILTER_OBJECT_MARKER, FILTER_COMPOSITION_MARKER } from './constants';
 


### PR DESCRIPTION
- Fixes conflicting issue with imports:
`node_modules/refilterable/dist/utils/types.d.ts:1:10 - error TS2440: Import declaration conflicts with local declaration of 'FilterComposition'.`

- Fixes a typescript issue FilterProvider children prop.